### PR TITLE
Make Nibbles compatible with the latest major GHC version

### DIFF
--- a/Args.hs
+++ b/Args.hs
@@ -11,7 +11,7 @@ import Parse (parseError,onlyCheckMatchIdentifier)
 import Data.List
 import Data.Maybe
 import Control.Monad.State -- needs cabal install --lib mtl
-import qualified Data.Set as Set
+import qualified Data.Set as Set -- needs cabal install --lib containers
 
 argStr n tn = "arg" ++ show n ++ "t" ++ show tn
 letStr n tn = "larg" ++ show n ++ "t" ++ show tn

--- a/Args.hs
+++ b/Args.hs
@@ -10,7 +10,7 @@ import Parse (parseError,onlyCheckMatchIdentifier)
 
 import Data.List
 import Data.Maybe
-import State
+import Control.Monad.State -- needs cabal install --lib mtl
 import qualified Data.Set as Set
 
 argStr n tn = "arg" ++ show n ++ "t" ++ show tn

--- a/Compile.hs
+++ b/Compile.hs
@@ -4,7 +4,7 @@ module Compile(compile,padToEvenNibbles,charClassesDefs) where
 
 import Data.List(inits,intercalate,nub)
 import Data.Maybe
-import State
+import Control.Monad.State -- needs cabal install --lib mtl
 import qualified Data.Set as Set
 
 import Polylib(coerceTo,fillAccums,join,truthy,curryN,rotateTuple,flattenTuples,fullVectorize,baseElem,cidim,promoteListRepeat,promoteList,coerce,minForType,maxForType,defaultValue)

--- a/Compile.hs
+++ b/Compile.hs
@@ -5,7 +5,7 @@ module Compile(compile,padToEvenNibbles,charClassesDefs) where
 import Data.List(inits,intercalate,nub)
 import Data.Maybe
 import Control.Monad.State -- needs cabal install --lib mtl
-import qualified Data.Set as Set
+import qualified Data.Set as Set -- needs cabal install --lib containers
 
 import Polylib(coerceTo,fillAccums,join,truthy,curryN,rotateTuple,flattenTuples,fullVectorize,baseElem,cidim,promoteListRepeat,promoteList,coerce,minForType,maxForType,defaultValue)
 import Ops

--- a/Expr.hs
+++ b/Expr.hs
@@ -1,6 +1,6 @@
 module Expr where
 
-import State
+import Control.Monad.State -- needs cabal install --lib mtl
 import qualified Data.DList as DList -- needs cabal install --lib dlist
 
 import Types

--- a/Expr.hs
+++ b/Expr.hs
@@ -6,7 +6,7 @@ import qualified Data.DList as DList -- needs cabal install --lib dlist
 import Types
 import Hs
 import SmartList
-import qualified Data.Set as Set
+import qualified Data.Set as Set -- needs cabal install --lib containers
 
 
 -- if change, change downloads.md

--- a/FileQuoter.hs
+++ b/FileQuoter.hs
@@ -1,7 +1,7 @@
 module FileQuoter where
 
-import Language.Haskell.TH
-import Language.Haskell.TH.Quote
+import Language.Haskell.TH -- needs cabal install --lib template-haskell
+import Language.Haskell.TH.Quote -- needs cabal install --lib template-haskell
 
 -- Quasi-quoter for adding files as string constants
 -- Taken from https://stackoverflow.com/a/12717160/7588488 via Husk

--- a/Header.hs
+++ b/Header.hs
@@ -11,7 +11,7 @@ import Data.List.Split -- needs cabal install --lib split
 import Text.Read (readMaybe)
 import Data.Function (fix)
 import System.IO
-import qualified Data.Set as Set
+import qualified Data.Set as Set -- needs cabal install --lib containers
 import System.Environment
 import Control.Monad (when)
 import GHC.IO.Encoding

--- a/Header.hs
+++ b/Header.hs
@@ -17,7 +17,7 @@ import Control.Monad (when)
 import GHC.IO.Encoding
 
 -- for Hash
-import qualified Data.ByteString as B8
+import qualified Data.ByteString as B8 -- needs cabal install --lib bytestring
 import qualified Data.Digest.Murmur64 as Murmur -- needs cabal install --lib murmur-hash
 
 newli = myOrd '\n'

--- a/Ops.hs
+++ b/Ops.hs
@@ -9,7 +9,7 @@ import Args
 import Hs
 import OpsHelper
 
-import State
+import Control.Monad.State -- needs cabal install --lib mtl
 import Data.List(concat,sortOn)
 import Data.Maybe
 
@@ -278,9 +278,7 @@ rawOps = [
    -- hidden Example: / | `,~ - ~ $ -> 0
    -- Test tuple: / |`.~1 0 \a b - a ~ b \a b a -> 1
    -- Test: /,0 -> 0
-   op(('/',10), [list, EOF], \[a1] -> do
-      modify $ \s -> s { pdImplicitArgUsed = True }
-      return $ "\\a -> if null a then "++defaultValue (elemT a1)++" else head a" ~> elemT a1),
+   op(('/',10), [list, EOF], \[a1] -> "\\a -> if null a then "++defaultValue (elemT a1)++" else head a" ~> elemT a1),
 
    -- Desc: foldr1
    -- Example: /,3+@$ -> 6

--- a/Parse.hs
+++ b/Parse.hs
@@ -35,7 +35,7 @@ import Header (at,fromBase,toBase)
 import Data.Char
 import Numeric (showOct,showHex)
 import Data.Maybe (fromMaybe)
-import State
+import Control.Monad.State -- needs cabal install --lib mtl
 
 import Text.ParserCombinators.ReadP (gather, readP_to_S)
 import Text.Read.Lex as Lex (readDecP, readHexP, lex, Lexeme(String), Lexeme(Char))

--- a/docs/try_it.md
+++ b/docs/try_it.md
@@ -1,30 +1,64 @@
-# Try it
+# Try Nibbles
 
-## Run Online
+## Playground
 
 [Attempt This Online](https://ato.pxeger.com/run?1=m708LzMpKSe1eMGCpaUlaboW65U8UnNy8nUUyvOLclIUlSCiUEmYIgA)
 
-## Install Locally
+## Building from source
 
-### Install Haskell
-You will need **GHC 8.0.2 - 8.10.7**. I recommend using [ghcup](https://www.haskell.org/ghcup/) to get it.
+### Install GHC
+Nibbles compiles to Haskell and therefore requires a suitable compiler.
+We strongly recommend using [GHCup](https://www.haskell.org/ghcup/) to obtain a copy of GHC, the [Glasgow Haskell Compiler](https://www.haskell.org/ghc/).
 
-### Install Nibbles
-Download the [latest version](nibbles-latest.tgz) ([or old](downloads.html)), unpack it then compile it.
+> [!NOTE]  
+> At the time of writing, the Nibbles project is fully compatible with [all released versions](https://gitlab.haskell.org/ghc/ghc/-/wikis/GHC%20Status#all-released-ghc-versions) from **8.0.2** through **9.12.2**.
 
-   > cd nibbles
-   > ghc -O -package ghc *.hs
+### Build Nibbles
+Download the tarball file of the [latest release](nibbles-latest.tgz) and extract the archive.
+You can also download a tarball file from a [previous release](downloads.html) or clone the [project repository](https://github.com/darrenks/nibbles) on GitHub.
 
-This creates the `nibbles` binary. You will need to run nibbles code from this directory unless you install the libraries below.
+Compile the project to generate the `nibbles` executable in the current working directory.
 
-### Note on libraries
+```bash
+$ cd nibbles
+$ ghc -O -package ghc nibbles.hs
+```
 
-The .tgz file contains the source of the libraries it depends on. If you prefer to instead download them do so as follows.
+> [!NOTE]  
+> If the compilation aborts prematurely with errors, please refer to the section on [installing packages](try_it.md#install-packages).
 
-   > rm -r Data # (removes the predownloaded libraries)
-   > cabal install --lib dlist split murmur-hash memoize
+> [!IMPORTANT]  
+> Future source files containing Nibbles code should be compiled and then run from the directory containing the `nibbles` executable, except when installing the packages in the next section.
 
+### Install packages
 
-### Other versions of Haskell
+Release tarballs (.tgz) contain bundled package dependencies. However, if you prefer to install them manually, you can do so as follows:
 
-Other versions of Haskell might work, I just haven't tried them yet. You may run all the nibbles tests to check compatibility with `ruby test/testall.rb`. Please let me know if you have any troubles with 8.0.2 - 8.10.7 or if you are able to get other versions to work and how.
+```bash
+$ rm -r Data
+$ cabal install --lib bytestring containers dlist filepath memoize mtl murmur-hash process split template-haskell
+```
+
+> [!WARNING]  
+> Starting with GHC version **9.8.1**, you should omit "memoize" from the above installation command and download the package tarball from [Hackage](https://hackage.haskell.org/package/memoize), the Haskell package repository. You can also clone the [package repository](https://github.com/tov/memoize) on GitHub or download the same tarball from the [Releases](https://github.com/tov/memoize/releases) page.
+>
+> Run the following command from the package root directory:
+> 
+> ```bash
+> $ sed -i 's/()/BndrVis/' src/Data/Function/Memoize/TH.hs
+> ```
+>
+> Alternatively, depending on how you obtained the package source code, you can manually replace the `()` on [this line](https://github.com/tov/memoize/blob/dc745b32068ff2411228ccbb70e5b86ee193aad8/src/Data/Function/Memoize/TH.hs#L159) with `BndrVis`.
+
+### Run tests (optional)
+
+If you want to check the compatibility of the Nibbles project with your current Haskell compiler, you can run the following command:
+
+```bash
+$ ruby test/testall.rb
+```
+
+---
+
+> [!TIP]
+> If you encounter any issues with compilation and/or installation, please [report](https://github.com/darrenks/nibbles/issues/new) them via GitHub.

--- a/nibbles.hs
+++ b/nibbles.hs
@@ -5,8 +5,8 @@ import Data.List(isPrefixOf,partition,elemIndex)
 import System.Environment
 import System.IO
 import GHC.IO.Encoding
-import System.FilePath
-import System.Process
+import System.FilePath -- needs cabal install --lib filepath
+import System.Process -- needs cabal install --lib process
 import System.Exit
 import Control.Monad
 import Data.List(intercalate)

--- a/test/test.hs
+++ b/test/test.hs
@@ -5,7 +5,7 @@ import Expr
 import Types
 import Polylib
 
-import System.Process
+import System.Process -- needs cabal install --lib process
 import System.IO
 import Control.Monad (when)
 import Data.Maybe

--- a/web/quickref.hs
+++ b/web/quickref.hs
@@ -7,7 +7,7 @@ import Text.Blaze.Html5 as H hiding (main, map)
 import Text.Blaze.Html5.Attributes as A
 import Control.Monad (forM_, mapM_)
 import Text.Blaze.Html.Renderer.Utf8 (renderHtml)
-import qualified Data.ByteString.Lazy.Char8 as Char8
+import qualified Data.ByteString.Lazy.Char8 as Char8 -- needs cabal install --lib bytestring
 import Data.List (intercalate)
 
 import Ops


### PR DESCRIPTION
The import of the `State` module has been changed to `Control.Monad.State`.

Some imported modules require additional packages:

* `Control.Monad` -> [mtl](https://hackage.haskell.org/package/mtl)
* `Data.ByteString` -> [bytestring](https://hackage.haskell.org/package/bytestring)
* `Data.Set` -> [containers](https://hackage.haskell.org/package/containers)
* `Language.Haskell` -> [template-haskell](https://hackage.haskell.org/package/template-haskell)
* `System.FilePath` -> [filepath](https://hackage.haskell.org/package/filepath)
* `System.Process` -> [process](https://hackage.haskell.org/package/process)

Because of all the changes, it is now required to run the install command[^1] for additional packages, like this:

```bash
$ cabal install --lib bytestring containers dlist filepath memoize mtl murmur-hash process split template-haskell
```

I've also commented out the individual commands for any imports that didn't have this yet.

The changes in this pull request have been successfully tested on the following versions:

* 8.10.7
* 9.0.1
* 9.6.6
* 9.6.7
* 9.8.1
* 9.8.4
* 9.10.3
* 9.12.1
* 9.12.2

From the test results, I can conclude that the hack for the `Data.Function.Memoize` module is required from version 9.8.1 onwards. This hack consists of downloading and extracting the package [tarball](https://hackage.haskell.org/package/memoize-1.1.2/memoize-1.1.2.tar.gz) and running the following commands in the package's root directory:

```bash
$ sed -i 's/()/BndrVis/' src/Data/Function/Memoize/TH.hs
$ cabal install --lib memoize --project-dir .
```

This commit also fixes the issue in this [comment](https://github.com/code-golf/code-golf/issues/1595#issuecomment-3100703629).

[^1]: Since version 9.8.1, "memoize" must be omitted from the command and the package must be installed using the tarball hack.